### PR TITLE
Quote URLs to guarantee data type

### DIFF
--- a/input/fsh/Vocabulary.fsh
+++ b/input/fsh/Vocabulary.fsh
@@ -121,7 +121,7 @@ Id:          pa-task-status
 Title:       "PA Referral Task Status"
 Description: "Codes indicating allowed for Tasks seeking fulfillment of physical activity-related referrals"
 * ^experimental = false
-* ^compose.include[0].valueSet = http://hl7.org/fhir/ValueSet/task-status
-* ^compose.exclude[0].system = http://hl7.org/fhir/task-status
+* ^compose.include[0].valueSet = "http://hl7.org/fhir/ValueSet/task-status"
+* ^compose.exclude[0].system = "http://hl7.org/fhir/task-status"
 * ^compose.exclude[0].concept[+].code = #received
 * ^compose.exclude[0].concept[+].code = #ready


### PR DESCRIPTION
Upcoming changes in SUSHI version 3 allow for Instance assignment in rules that previously did not permit Instance assignment. This change is consistent with the existing FSH specification. The changes in this PR will help avoid errors when using SUSHI version 3.